### PR TITLE
refactor: Move API functions into hooks and de-couple

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -6,13 +6,34 @@ import {
   UserCenter,
 } from "./components";
 import { useSurvivors } from "./hooks";
-import { useSearchStore, useSurvivorStore } from "./stores";
+import { useSearchStore, useSurvivorStore, useToastsStore } from "./stores";
 
 export function App() {
   const myId = useSurvivorStore((state) => state.id);
   const maxDistance = useSearchStore((state) => state.maxDistance);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
-  const { data: survivors } = useSurvivors({ identifier: myId, maxDistance });
+  const { data: survivors } = useSurvivors({
+    identifier: myId,
+    maxDistance,
+    onError: (err) => {
+      if (err.message.includes("Unexpected token")) {
+        openToast({
+          id: "load-survivors-data-corrupted",
+          title: "Error",
+          description: "Survivors data is corrupted",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "load-survivors-error",
+        title: "Error",
+        description: "An error occurred while loading survivors",
+        type: "error",
+      });
+    },
+  });
 
   return (
     <div className="p-4 sm:p-6">

--- a/frontend/src/components/inventory.tsx
+++ b/frontend/src/components/inventory.tsx
@@ -7,6 +7,7 @@ import { FaMinus, FaPlus } from "react-icons/fa";
 // internals
 import { useItems } from "../hooks";
 import { Inventory as TInventory } from "../types";
+import { useToastsStore } from "../stores";
 
 interface InventoryProps {
   items: TInventory;
@@ -28,7 +29,27 @@ export function Inventory({
   grid = false,
   setInventory,
 }: InventoryProps) {
-  const possibleItems = useItems();
+  const openToast = useToastsStore((state) => state.actions.openToast);
+
+  const { data: possibleItems } = useItems({
+    onError: (err) => {
+      if (err.message.includes("Unexpected token")) {
+        openToast({
+          id: "load-items-data-corrupted",
+          title: "Error",
+          description: "Items data is corrupted",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "load-items-error",
+        title: "Error",
+        description: "An error occurred while loading items",
+        type: "error",
+      });
+    },
+  });
 
   return (
     <>

--- a/frontend/src/components/location-editor.tsx
+++ b/frontend/src/components/location-editor.tsx
@@ -43,7 +43,12 @@ export function LocationEditor({
     identifier: myId,
     onSuccess: () => {
       identify(myId, myName, tempLatitude, tempLongitude);
-      openToast("location-update-success");
+      openToast({
+        id: "location-update-success",
+        title: "Location updated",
+        description: "Your location has been updated successfully",
+        type: "success",
+      });
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.GetSurvivors, myId, maxDistance],
       });

--- a/frontend/src/components/location-editor.tsx
+++ b/frontend/src/components/location-editor.tsx
@@ -56,6 +56,24 @@ export function LocationEditor({
         queryKey: [QueryKeys.GetSurvivor, myId],
       });
     },
+    onError: (err) => {
+      if (err.message === "Unauthorized") {
+        openToast({
+          id: "location-update-unauthorized",
+          title: "Location update failed",
+          description:
+            "You are not authorized to update another survivor's location",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "location-update-error",
+        title: "Location update failed",
+        description: "An error occurred while updating your location",
+        type: "error",
+      });
+    },
   });
 
   return (

--- a/frontend/src/components/register.tsx
+++ b/frontend/src/components/register.tsx
@@ -6,44 +6,19 @@ import {
   Separator,
   TextField,
 } from "@radix-ui/themes";
-import { useMutation } from "@tanstack/react-query";
-import { ChangeEvent, useCallback, useState } from "react";
+import { ChangeEvent, useState } from "react";
 
 // internals
-import { useShallow } from "zustand/react/shallow";
 import { GenderIndicator, Inventory, LocationEditor } from ".";
 import { isSurvivor } from "../helpers";
-import { Toast, useSurvivorStore, useToastsStore } from "../stores";
-import { Gender, LatLon, Survivor, Inventory as TInventory } from "../types";
+import { useCreateSurvivor } from "../hooks";
+import { useSurvivorStore } from "../stores";
+import { Gender, LatLon, Inventory as TInventory } from "../types";
 
 const DEFAULT_AGE = 18;
 
-const TOASTS: Record<string, Toast> = {
-  "registration-success": {
-    title: "Welcome!",
-    description: "You have been added to the system!",
-    type: "success",
-    open: false,
-  },
-  "registration-error": {
-    title: "Failed to create",
-    description: "An error occurred while adding you to the system",
-    type: "error",
-    open: false,
-  },
-};
-
 export function Register() {
   const identify = useSurvivorStore((state) => state.actions.identify);
-
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
 
   const [name, setName] = useState("");
   const [age, setAge] = useState<number>(DEFAULT_AGE);
@@ -61,33 +36,7 @@ export function Register() {
     setInventory({});
   };
 
-  const mutationFn = useCallback(
-    async (data: Survivor) => {
-      const headers = new Headers();
-      headers.append("Content-Type", "application/json");
-
-      const response = await fetch("/api/survivors/", {
-        method: "POST",
-        headers,
-        body: JSON.stringify(data),
-      });
-
-      if (!response.ok) {
-        openToast("registration-error");
-        throw new Error("An error occurred");
-      }
-      try {
-        return await response.json();
-      } catch (err) {
-        openToast("registration-error");
-        throw err;
-      }
-    },
-    [openToast],
-  );
-
-  const mutation = useMutation({
-    mutationFn,
+  const { mutate } = useCreateSurvivor({
     onSuccess: (data) => {
       if (isSurvivor(data) && data.name === name && data.id) {
         identify(
@@ -176,8 +125,8 @@ export function Register() {
         <Dialog.Close>
           <Button
             disabled={!name || !age || !gender || !latitude || !longitude}
-            onClick={async () => {
-              await mutation.mutate({
+            onClick={() =>
+              mutate({
                 name,
                 age: age!,
                 gender: gender!,
@@ -186,8 +135,8 @@ export function Register() {
                   longitude: longitude!,
                 },
                 inventory,
-              });
-            }}
+              })
+            }
           >
             Register
           </Button>

--- a/frontend/src/components/register.tsx
+++ b/frontend/src/components/register.tsx
@@ -12,13 +12,14 @@ import { ChangeEvent, useState } from "react";
 import { GenderIndicator, Inventory, LocationEditor } from ".";
 import { isSurvivor } from "../helpers";
 import { useCreateSurvivor } from "../hooks";
-import { useSurvivorStore } from "../stores";
+import { useSurvivorStore, useToastsStore } from "../stores";
 import { Gender, LatLon, Inventory as TInventory } from "../types";
 
 const DEFAULT_AGE = 18;
 
 export function Register() {
   const identify = useSurvivorStore((state) => state.actions.identify);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const [name, setName] = useState("");
   const [age, setAge] = useState<number>(DEFAULT_AGE);
@@ -45,6 +46,12 @@ export function Register() {
           data.lastLocation.latitude,
           data.lastLocation.longitude,
         );
+        openToast({
+          id: "register-success",
+          title: "Welcome!",
+          description: "You have been added to the survivor list",
+          type: "success",
+        });
       }
     },
     onSettled: resetValues,

--- a/frontend/src/components/register.tsx
+++ b/frontend/src/components/register.tsx
@@ -54,6 +54,14 @@ export function Register() {
         });
       }
     },
+    onError: () => {
+      openToast({
+        id: "create-survivor-error",
+        title: "Failed to create",
+        description: "An error occurred while adding you to the system",
+        type: "error",
+      });
+    },
     onSettled: resetValues,
   });
 

--- a/frontend/src/components/sign-in.tsx
+++ b/frontend/src/components/sign-in.tsx
@@ -6,9 +6,11 @@ import { useShallow } from "zustand/react/shallow";
 // internals
 import { isSurvivor } from "../helpers";
 import { useSurvivor } from "../hooks";
-import { useSurvivorStore } from "../stores";
+import { useSurvivorStore, useToastsStore } from "../stores";
 
 export function SignIn() {
+  const openToast = useToastsStore((state) => state.actions.openToast);
+
   const { identify, updateInventory } = useSurvivorStore(
     useShallow((state) => ({
       identify: state.actions.identify,
@@ -37,6 +39,31 @@ export function SignIn() {
       }
 
       setName("");
+    },
+    onError: (err) => {
+      if (err.message === "Not Found") {
+        openToast({
+          id: "loadprofile-not-fount",
+          title: "Error",
+          description: "Could not find survivor in the system",
+          type: "error",
+        });
+        return;
+      } else if (err.message.includes("Unexpected token")) {
+        openToast({
+          id: "loadprofile-data-corrupted",
+          title: "Error",
+          description: "Survivor data is corrupted",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "loadprofile-error",
+        title: "Error",
+        description: "An error occurred while loading survivor",
+        type: "error",
+      });
     },
   });
 

--- a/frontend/src/components/sign-in.tsx
+++ b/frontend/src/components/sign-in.tsx
@@ -1,34 +1,12 @@
 // libs
 import { Button, Dialog, TextField } from "@radix-ui/themes";
-import { useQuery } from "@tanstack/react-query";
 import { ChangeEvent, useState } from "react";
 import { useShallow } from "zustand/react/shallow";
 
 // internals
 import { isSurvivor } from "../helpers";
-import { Toast, useSurvivorStore, useToastsStore } from "../stores";
-import { ErrorState, Survivor } from "../types";
-
-const TOASTS: Record<string, Toast> = {
-  "signin-not-fount": {
-    title: "Error",
-    description: "Could not find anyone in the system with that name",
-    type: "error",
-    open: false,
-  },
-  "signin-error": {
-    title: "Error",
-    description: "An error occurred while signing in",
-    type: "error",
-    open: false,
-  },
-  "signin-data-corrupted": {
-    title: "Error",
-    description: "Your profile data is corrupted",
-    type: "error",
-    open: false,
-  },
-};
+import { useSurvivorStore } from "../stores";
+import { useSurvivor } from "../hooks";
 
 export function SignIn() {
   const { identify, updateInventory } = useSurvivorStore(
@@ -38,38 +16,28 @@ export function SignIn() {
     })),
   );
 
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
-
   const [name, setName] = useState("");
 
-  const { refetch, isFetching } = useQuery<Survivor | ErrorState>({
-    queryKey: ["get-survivor", name],
-    queryFn: async () => {
-      const response = await fetch(`/api/survivors/${name}`);
-
-      if (!response.ok) {
-        if (response.status === 404) {
-          openToast("signin-not-fount");
-          throw new Error("Not found");
-        }
-        openToast("signin-error");
-        throw new Error("An error occurred");
-      }
-      try {
-        return await response.json();
-      } catch (err) {
-        openToast("signin-data-corrupted");
-        throw err;
-      }
-    },
+  const { isFetching, refetch } = useSurvivor({
+    identifier: name,
     enabled: false,
+    onSuccess: (data) => {
+      if (
+        isSurvivor(data) &&
+        data.name.toLocaleLowerCase() === name.toLocaleLowerCase() &&
+        data.id
+      ) {
+        identify(
+          data.id,
+          data.name,
+          data.lastLocation.latitude,
+          data.lastLocation.longitude,
+        );
+        updateInventory(data.inventory);
+      }
+
+      setName("");
+    },
   });
 
   return (
@@ -103,24 +71,7 @@ export function SignIn() {
         </Dialog.Close>
         <Dialog.Close>
           <Button
-            onClick={async () => {
-              const { data } = await refetch();
-              if (
-                isSurvivor(data) &&
-                data.name.toLocaleLowerCase() === name.toLocaleLowerCase() &&
-                data.id
-              ) {
-                identify(
-                  data.id,
-                  data.name,
-                  data.lastLocation.latitude,
-                  data.lastLocation.longitude,
-                );
-                updateInventory(data.inventory);
-              }
-
-              setName("");
-            }}
+            onClick={() => refetch()}
             disabled={name === ""}
             loading={name !== "" && isFetching}
           >

--- a/frontend/src/components/sign-in.tsx
+++ b/frontend/src/components/sign-in.tsx
@@ -5,8 +5,8 @@ import { useShallow } from "zustand/react/shallow";
 
 // internals
 import { isSurvivor } from "../helpers";
-import { useSurvivorStore } from "../stores";
 import { useSurvivor } from "../hooks";
+import { useSurvivorStore } from "../stores";
 
 export function SignIn() {
   const { identify, updateInventory } = useSurvivorStore(

--- a/frontend/src/components/survivor-card.tsx
+++ b/frontend/src/components/survivor-card.tsx
@@ -36,7 +36,12 @@ export function SurvivorCard({ survivor }: SurvivorCardProps) {
     identifier: myId,
     survivor: survivor.id,
     onSuccess: () => {
-      openToast("report-success");
+      openToast({
+        id: "report-success",
+        title: "Infection reported!",
+        description: "Thank you! Stay safe out there!",
+        type: "success",
+      });
       queryClient.invalidateQueries({
         queryKey: [QueryKeys.GetSurvivors, myId, maxDistance],
       });

--- a/frontend/src/components/survivor-card.tsx
+++ b/frontend/src/components/survivor-card.tsx
@@ -46,6 +46,23 @@ export function SurvivorCard({ survivor }: SurvivorCardProps) {
         queryKey: [QueryKeys.GetSurvivors, myId, maxDistance],
       });
     },
+    onError: (err) => {
+      if (err.message === "Unauthorized") {
+        openToast({
+          id: "report-unauthorized",
+          title: "Unauthorized",
+          description: "Your id doesn't match any we have in the system",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "report-error",
+        title: "Failed to report",
+        description: "An error occurred while adding your report to the system",
+        type: "error",
+      });
+    },
   });
 
   return (

--- a/frontend/src/components/trading-panel.tsx
+++ b/frontend/src/components/trading-panel.tsx
@@ -66,10 +66,12 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
     ...myInventory,
   });
   const [myOffer, setMyOffer] = useState<TInventory>();
+  const [myOfferValue, setMyOfferValue] = useState<number>(0);
   const [theirInventory, setTheirInventory] = useState<TInventory>({
     ...tradingPartner.inventory,
   });
   const [theirOffer, setTheirOffer] = useState<TInventory>();
+  const [theirOfferValue, setTheirOfferValue] = useState<number>(0);
 
   const getUpdatedInventory = (inventory: TInventory, offer: TInventory) => {
     const update = { ...emptyOffer };
@@ -79,6 +81,12 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
     }
     return update;
   };
+
+  const calculateNetValue = (inventory: TInventory) =>
+    possibleItems!.reduce((acc, item) => {
+      acc += item.worth * (inventory[item.id] ?? 0);
+      return acc;
+    }, 0);
 
   const queryClient = useQueryClient();
 
@@ -106,6 +114,7 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
               setInventory={(offer) => {
                 setMyOffer({ ...offer });
                 setMyTempInventory(getUpdatedInventory(myInventory, offer));
+                setMyOfferValue(calculateNetValue(offer));
               }}
             />
           </div>
@@ -131,6 +140,7 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
                 setTheirInventory(
                   getUpdatedInventory(tradingPartner.inventory, offer),
                 );
+                setTheirOfferValue(calculateNetValue(offer));
               }}
             />
           </div>
@@ -143,7 +153,14 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
         </Dialog.Close>
         <Dialog.Close>
           <Button
-            disabled={!tradingPartner.id || !myOffer || !theirOffer}
+            disabled={
+              !tradingPartner.id ||
+              !myOffer ||
+              !theirOffer ||
+              !myOfferValue ||
+              !theirOfferValue ||
+              myOfferValue !== theirOfferValue
+            }
             onClick={() =>
               mutate({
                 survivor_a_items: { survivor_id: myId!, items: myOffer! },

--- a/frontend/src/components/trading-panel.tsx
+++ b/frontend/src/components/trading-panel.tsx
@@ -27,7 +27,12 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
   const { mutate } = useTrade({
     identifier: myId,
     onSuccess: async () => {
-      openToast("trade-success");
+      openToast({
+        id: "trade-success",
+        title: "Trade successful",
+        description: "Items have been traded successfully",
+        type: "success",
+      });
 
       setMyTempInventory({
         ...myInventory,

--- a/frontend/src/components/trading-panel.tsx
+++ b/frontend/src/components/trading-panel.tsx
@@ -26,7 +26,7 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
 
   const { mutate } = useTrade({
     identifier: myId,
-    onSuccess: async () => {
+    onSuccess: () => {
       openToast({
         id: "trade-success",
         title: "Trade successful",
@@ -49,9 +49,35 @@ export function TradingPanel({ tradingPartner }: TradingPanelProps) {
         queryKey: [QueryKeys.GetSurvivors, myId, maxDistance],
       });
     },
+    onError: () => {
+      openToast({
+        id: "trade-error",
+        title: "Trade failed",
+        description: "An error occurred while trading items",
+        type: "error",
+      });
+    },
   });
 
-  const possibleItems = useItems();
+  const { data: possibleItems } = useItems({
+    onError: (err) => {
+      if (err.message.includes("Unexpected token")) {
+        openToast({
+          id: "load-items-data-corrupted",
+          title: "Error",
+          description: "Items data is corrupted",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "load-items-error",
+        title: "Error",
+        description: "An error occurred while loading items",
+        type: "error",
+      });
+    },
+  });
 
   const emptyOffer = useMemo(
     () =>

--- a/frontend/src/components/user-control.tsx
+++ b/frontend/src/components/user-control.tsx
@@ -12,9 +12,11 @@ import { useShallow } from "zustand/react/shallow";
 import { Register, SignIn, UserPanel } from ".";
 import { isSurvivor } from "../helpers";
 import { useSurvivor } from "../hooks";
-import { useSurvivorStore } from "../stores";
+import { useSurvivorStore, useToastsStore } from "../stores";
 
 export function UserCenter() {
+  const openToast = useToastsStore((state) => state.actions.openToast);
+
   const { identify, myId, myName, updateInventory } = useSurvivorStore(
     useShallow((state) => ({
       myId: state.id,
@@ -37,6 +39,31 @@ export function UserCenter() {
         );
         updateInventory(data.inventory);
       }
+    },
+    onError: (err) => {
+      if (err.message === "Not Found") {
+        openToast({
+          id: "loadprofile-not-fount",
+          title: "Error",
+          description: "Could not find survivor in the system",
+          type: "error",
+        });
+        return;
+      } else if (err.message.includes("Unexpected token")) {
+        openToast({
+          id: "loadprofile-data-corrupted",
+          title: "Error",
+          description: "Survivor data is corrupted",
+          type: "error",
+        });
+        return;
+      }
+      openToast({
+        id: "loadprofile-error",
+        title: "Error",
+        description: "An error occurred while loading survivor",
+        type: "error",
+      });
     },
   });
 

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -4,6 +4,12 @@ import { v4 as uuid } from "uuid";
 // internals
 import { Item, Survivor } from "./types";
 
+export enum QueryKeys {
+  GetSurvivors = "get-survivors",
+  GetSurvivor = "get-survivor",
+  GetItems = "get-items",
+}
+
 export const MOCK_POSSIBLE_ITEMS: Item[] = [
   {
     id: uuid(),

--- a/frontend/src/constants.ts
+++ b/frontend/src/constants.ts
@@ -39,7 +39,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "John Doe",
     age: 30,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 34.0522, longitude: 118.2437 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 34.0522,
+      longitude: 118.2437,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[1].id]: 1,
@@ -51,7 +56,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Jane Smith",
     age: 25,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 40.7128, longitude: -74.006 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 40.7128,
+      longitude: -74.006,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[2].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -63,7 +73,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Alice Johnson",
     age: 28,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 37.7749, longitude: -122.4194 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 37.7749,
+      longitude: -122.4194,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -75,7 +90,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Bob Brown",
     age: 35,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 51.5074, longitude: -0.1278 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 51.5074,
+      longitude: -0.1278,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -87,7 +107,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Charlie Davis",
     age: 40,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 48.8566, longitude: 2.3522 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 48.8566,
+      longitude: 2.3522,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -99,7 +124,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Diana Evans",
     age: 22,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 35.6895, longitude: 139.6917 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 35.6895,
+      longitude: 139.6917,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -111,7 +141,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Ethan Foster",
     age: 27,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 55.7558, longitude: 37.6173 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 55.7558,
+      longitude: 37.6173,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -123,7 +158,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Fiona Green",
     age: 32,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 39.9042, longitude: 116.4074 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 39.9042,
+      longitude: 116.4074,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[1].id]: 1,
@@ -135,7 +175,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "George Harris",
     age: 29,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 34.0522, longitude: -118.2437 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 34.0522,
+      longitude: -118.2437,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[2].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -147,7 +192,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Hannah Irving",
     age: 24,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 40.7128, longitude: -74.006 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 40.7128,
+      longitude: -74.006,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -159,7 +209,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Ian Jackson",
     age: 31,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 37.7749, longitude: -122.4194 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 37.7749,
+      longitude: -122.4194,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -171,7 +226,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Julia King",
     age: 26,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 51.5074, longitude: -0.1278 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 51.5074,
+      longitude: -0.1278,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -183,7 +243,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Kevin Lewis",
     age: 33,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 48.8566, longitude: 2.3522 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 48.8566,
+      longitude: 2.3522,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -195,7 +260,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Laura Martinez",
     age: 21,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 35.6895, longitude: 139.6917 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 35.6895,
+      longitude: 139.6917,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -207,7 +277,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Michael Nelson",
     age: 34,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 55.7558, longitude: 37.6173 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 55.7558,
+      longitude: 37.6173,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[1].id]: 1,
@@ -219,7 +294,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Nina Owens",
     age: 28,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 39.9042, longitude: 116.4074 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 39.9042,
+      longitude: 116.4074,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[2].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -231,7 +311,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Oscar Perez",
     age: 30,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 34.0522, longitude: -118.2437 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 34.0522,
+      longitude: -118.2437,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,
@@ -243,7 +328,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Paula Quinn",
     age: 27,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 40.7128, longitude: -74.006 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 40.7128,
+      longitude: -74.006,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -255,7 +345,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Quincy Roberts",
     age: 32,
     gender: "m",
-    lastLocation: { id: uuid(), latitude: 37.7749, longitude: -122.4194 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 37.7749,
+      longitude: -122.4194,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[1].id]: 2,
       [MOCK_POSSIBLE_ITEMS[2].id]: 1,
@@ -274,7 +369,12 @@ export const MOCK_SURVIVORS: Survivor[] = [
     name: "Rachel Scott",
     age: 25,
     gender: "f",
-    lastLocation: { id: uuid(), latitude: 51.5074, longitude: -0.1278 },
+    lastLocation: {
+      id: uuid(),
+      distance: 0,
+      latitude: 51.5074,
+      longitude: -0.1278,
+    },
     inventory: {
       [MOCK_POSSIBLE_ITEMS[0].id]: 2,
       [MOCK_POSSIBLE_ITEMS[3].id]: 1,

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,1 +1,7 @@
+export * from "./use-create-survivor.hook";
 export * from "./use-items.hook";
+export * from "./use-report-infection.hook";
+export * from "./use-survivor.hook";
+export * from "./use-survivors.hook";
+export * from "./use-trade.hook";
+export * from "./use-update-survivor.hook";

--- a/frontend/src/hooks/use-create-survivor.hook.ts
+++ b/frontend/src/hooks/use-create-survivor.hook.ts
@@ -1,23 +1,7 @@
-import { useShallow } from "zustand/react/shallow";
-import { Toast, useToastsStore } from "../stores";
+import { useToastsStore } from "../stores";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
 import { Survivor, SurvivorBase } from "../types";
-
-const TOASTS: Record<string, Toast> = {
-  "create-survivor-success": {
-    title: "Welcome!",
-    description: "You have been added to the system!",
-    type: "success",
-    open: false,
-  },
-  "create-survivor-error": {
-    title: "Failed to create",
-    description: "An error occurred while adding you to the system",
-    type: "error",
-    open: false,
-  },
-};
 
 interface UseCreateSurvivorProps {
   onSuccess: (data: Survivor) => void;
@@ -27,14 +11,7 @@ export const useCreateSurvivor = ({
   onSuccess,
   onSettled,
 }: UseCreateSurvivorProps) => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const mutationFn = useCallback(
     async (data: SurvivorBase) => {
@@ -48,13 +25,23 @@ export const useCreateSurvivor = ({
       });
 
       if (!response.ok) {
-        openToast("registration-error");
+        openToast({
+          id: "create-survivor-error",
+          title: "Failed to create",
+          description: "An error occurred while adding you to the system",
+          type: "error",
+        });
         throw new Error("An error occurred");
       }
       try {
         return await response.json();
       } catch (err) {
-        openToast("registration-error");
+        openToast({
+          id: "create-survivor-error",
+          title: "Failed to create",
+          description: "An error occurred while adding you to the system",
+          type: "error",
+        });
         throw err;
       }
     },

--- a/frontend/src/hooks/use-create-survivor.hook.ts
+++ b/frontend/src/hooks/use-create-survivor.hook.ts
@@ -1,56 +1,40 @@
-import { useToastsStore } from "../stores";
+// libs
 import { useMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
+
+// internals
 import { Survivor, SurvivorBase } from "../types";
 
 interface UseCreateSurvivorProps {
   onSuccess: (data: Survivor) => void;
+  onError: (err: Error) => void;
   onSettled: () => void;
 }
 export const useCreateSurvivor = ({
   onSuccess,
+  onError,
   onSettled,
 }: UseCreateSurvivorProps) => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
+  const mutationFn = useCallback(async (data: SurvivorBase) => {
+    const headers = new Headers();
+    headers.append("Content-Type", "application/json");
 
-  const mutationFn = useCallback(
-    async (data: SurvivorBase) => {
-      const headers = new Headers();
-      headers.append("Content-Type", "application/json");
+    const response = await fetch("/api/survivors/", {
+      method: "POST",
+      headers,
+      body: JSON.stringify(data),
+    });
 
-      const response = await fetch("/api/survivors/", {
-        method: "POST",
-        headers,
-        body: JSON.stringify(data),
-      });
-
-      if (!response.ok) {
-        openToast({
-          id: "create-survivor-error",
-          title: "Failed to create",
-          description: "An error occurred while adding you to the system",
-          type: "error",
-        });
-        throw new Error("An error occurred");
-      }
-      try {
-        return await response.json();
-      } catch (err) {
-        openToast({
-          id: "create-survivor-error",
-          title: "Failed to create",
-          description: "An error occurred while adding you to the system",
-          type: "error",
-        });
-        throw err;
-      }
-    },
-    [openToast],
-  );
+    if (!response.ok) {
+      throw new Error("An error occurred");
+    }
+    return await response.json();
+  }, []);
 
   return useMutation({
     mutationFn,
     onSuccess,
+    onError,
     onSettled,
   });
 };

--- a/frontend/src/hooks/use-create-survivor.hook.ts
+++ b/frontend/src/hooks/use-create-survivor.hook.ts
@@ -2,7 +2,7 @@ import { useShallow } from "zustand/react/shallow";
 import { Toast, useToastsStore } from "../stores";
 import { useMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
-import { Survivor } from "../types";
+import { Survivor, SurvivorBase } from "../types";
 
 const TOASTS: Record<string, Toast> = {
   "create-survivor-success": {
@@ -37,7 +37,7 @@ export const useCreateSurvivor = ({
   setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
 
   const mutationFn = useCallback(
-    async (data: Survivor) => {
+    async (data: SurvivorBase) => {
       const headers = new Headers();
       headers.append("Content-Type", "application/json");
 

--- a/frontend/src/hooks/use-create-survivor.hook.ts
+++ b/frontend/src/hooks/use-create-survivor.hook.ts
@@ -1,0 +1,69 @@
+import { useShallow } from "zustand/react/shallow";
+import { Toast, useToastsStore } from "../stores";
+import { useMutation } from "@tanstack/react-query";
+import { useCallback } from "react";
+import { Survivor } from "../types";
+
+const TOASTS: Record<string, Toast> = {
+  "create-survivor-success": {
+    title: "Welcome!",
+    description: "You have been added to the system!",
+    type: "success",
+    open: false,
+  },
+  "create-survivor-error": {
+    title: "Failed to create",
+    description: "An error occurred while adding you to the system",
+    type: "error",
+    open: false,
+  },
+};
+
+interface UseCreateSurvivorProps {
+  onSuccess: (data: Survivor) => void;
+  onSettled: () => void;
+}
+export const useCreateSurvivor = ({
+  onSuccess,
+  onSettled,
+}: UseCreateSurvivorProps) => {
+  const { openToast, bulkRegisterToasts } = useToastsStore(
+    useShallow((state) => ({
+      openToast: state.actions.openToast,
+      bulkRegisterToasts: state.actions.bulkRegisterToasts,
+    })),
+  );
+  // Avoid updating ToastsEngine while this renders
+  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+
+  const mutationFn = useCallback(
+    async (data: Survivor) => {
+      const headers = new Headers();
+      headers.append("Content-Type", "application/json");
+
+      const response = await fetch("/api/survivors/", {
+        method: "POST",
+        headers,
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        openToast("registration-error");
+        throw new Error("An error occurred");
+      }
+      try {
+        return await response.json();
+      } catch (err) {
+        openToast("registration-error");
+        throw err;
+      }
+    },
+    [openToast],
+  );
+
+  return useMutation({
+    mutationFn,
+    onSuccess,
+    onSettled,
+  });
+};

--- a/frontend/src/hooks/use-items.hook.ts
+++ b/frontend/src/hooks/use-items.hook.ts
@@ -3,39 +3,24 @@ import { useQuery } from "@tanstack/react-query";
 
 // internals
 import { QueryKeys } from "../constants";
-import { useToastsStore } from "../stores";
 import { Item } from "../types";
 
-export const useItems = () => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
-
-  const { data: possibleItems } = useQuery<Item[]>({
+interface UseItemsProps {
+  onError: (err: Error) => void;
+}
+export const useItems = ({ onError }: UseItemsProps) =>
+  useQuery<Item[]>({
     queryKey: [QueryKeys.GetItems],
     queryFn: async () => {
       const response = await fetch("/api/items/");
 
       if (!response.ok) {
-        openToast({
-          id: "load-items-error",
-          title: "Error",
-          description: "An error occurred while loading items",
-          type: "error",
-        });
-        throw new Error("An error occurred");
+        onError(new Error("An error occurred"));
       }
       try {
         return await response.json();
       } catch (err) {
-        openToast({
-          id: "load-items-data-corrupted",
-          title: "Error",
-          description: "Items data is corrupted",
-          type: "error",
-        });
-        throw err;
+        onError(err as Error);
       }
     },
   });
-
-  return possibleItems;
-};

--- a/frontend/src/hooks/use-items.hook.ts
+++ b/frontend/src/hooks/use-items.hook.ts
@@ -3,6 +3,7 @@ import { useShallow } from "zustand/react/shallow";
 import { useQuery } from "@tanstack/react-query";
 
 // internals
+import { QueryKeys } from "../constants";
 import { Toast, useToastsStore } from "../stores";
 import { Item } from "../types";
 
@@ -32,7 +33,7 @@ export const useItems = () => {
   setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
 
   const { data: possibleItems } = useQuery<Item[]>({
-    queryKey: ["get-items"],
+    queryKey: [QueryKeys.GetItems],
     queryFn: async () => {
       const response = await fetch("/api/items/");
 

--- a/frontend/src/hooks/use-items.hook.ts
+++ b/frontend/src/hooks/use-items.hook.ts
@@ -1,36 +1,13 @@
 // libs
-import { useShallow } from "zustand/react/shallow";
 import { useQuery } from "@tanstack/react-query";
 
 // internals
 import { QueryKeys } from "../constants";
-import { Toast, useToastsStore } from "../stores";
+import { useToastsStore } from "../stores";
 import { Item } from "../types";
 
-const TOASTS: Record<string, Toast> = {
-  "load-items-error": {
-    title: "Error",
-    description: "An error occurred while loading items",
-    type: "error",
-    open: false,
-  },
-  "load-items-data-corrupted": {
-    title: "Error",
-    description: "Items data is corrupted",
-    type: "error",
-    open: false,
-  },
-};
-
 export const useItems = () => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const { data: possibleItems } = useQuery<Item[]>({
     queryKey: [QueryKeys.GetItems],
@@ -38,13 +15,23 @@ export const useItems = () => {
       const response = await fetch("/api/items/");
 
       if (!response.ok) {
-        openToast("load-items-error");
+        openToast({
+          id: "load-items-error",
+          title: "Error",
+          description: "An error occurred while loading items",
+          type: "error",
+        });
         throw new Error("An error occurred");
       }
       try {
         return await response.json();
       } catch (err) {
-        openToast("load-items-data-corrupted");
+        openToast({
+          id: "load-items-data-corrupted",
+          title: "Error",
+          description: "Items data is corrupted",
+          type: "error",
+        });
         throw err;
       }
     },

--- a/frontend/src/hooks/use-report-infection.hook.ts
+++ b/frontend/src/hooks/use-report-infection.hook.ts
@@ -2,21 +2,18 @@
 import { useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 
-// internals
-import { useToastsStore } from "../stores";
-
 interface UseReportInfectionProps {
   identifier: string | null;
   survivor: string;
   onSuccess: () => void;
+  onError: (err: Error) => void;
 }
 export const useReportInfection = ({
   identifier,
   survivor,
   onSuccess,
+  onError,
 }: UseReportInfectionProps) => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
-
   const mutationFn = useCallback(async () => {
     const headers = new Headers();
     headers.append("X-User-Id", identifier!);
@@ -28,27 +25,16 @@ export const useReportInfection = ({
 
     if (!response.ok) {
       if (response.status === 401) {
-        openToast({
-          id: "report-unauthorized",
-          title: "Unauthorized",
-          description: "Your id doesn't match any we have in the system",
-          type: "error",
-        });
         throw new Error("Unauthorized");
       }
-      openToast({
-        id: "report-error",
-        title: "Failed to report",
-        description: "An error occurred while adding your report to the system",
-        type: "error",
-      });
       throw new Error("An error occurred");
     }
     return await response.json();
-  }, [identifier, survivor, openToast]);
+  }, [identifier, survivor]);
 
   return useMutation({
     mutationFn,
     onSuccess,
+    onError,
   });
 };

--- a/frontend/src/hooks/use-report-infection.hook.ts
+++ b/frontend/src/hooks/use-report-infection.hook.ts
@@ -1,31 +1,9 @@
 // libs
 import { useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { useShallow } from "zustand/react/shallow";
 
 // internals
-import { Toast, useToastsStore } from "../stores";
-
-const TOASTS: Record<string, Toast> = {
-  "report-success": {
-    title: "Infection reported!",
-    description: "Thank you! Stay safe out there!",
-    type: "success",
-    open: false,
-  },
-  "report-unauthorized": {
-    title: "Unauthorized",
-    description: "Your id doesn't match any we have in the system",
-    type: "error",
-    open: false,
-  },
-  "report-error": {
-    title: "Failed to report",
-    description: "An error occurred while adding your report to the system",
-    type: "error",
-    open: false,
-  },
-};
+import { useToastsStore } from "../stores";
 
 interface UseReportInfectionProps {
   identifier: string | null;
@@ -37,14 +15,7 @@ export const useReportInfection = ({
   survivor,
   onSuccess,
 }: UseReportInfectionProps) => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const mutationFn = useCallback(async () => {
     const headers = new Headers();
@@ -57,10 +28,20 @@ export const useReportInfection = ({
 
     if (!response.ok) {
       if (response.status === 401) {
-        openToast("report-unauthorized");
+        openToast({
+          id: "report-unauthorized",
+          title: "Unauthorized",
+          description: "Your id doesn't match any we have in the system",
+          type: "error",
+        });
         throw new Error("Unauthorized");
       }
-      openToast("report-error");
+      openToast({
+        id: "report-error",
+        title: "Failed to report",
+        description: "An error occurred while adding your report to the system",
+        type: "error",
+      });
       throw new Error("An error occurred");
     }
     return await response.json();

--- a/frontend/src/hooks/use-report-infection.hook.ts
+++ b/frontend/src/hooks/use-report-infection.hook.ts
@@ -1,0 +1,73 @@
+// libs
+import { useCallback } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+
+// internals
+import { Toast, useToastsStore } from "../stores";
+
+const TOASTS: Record<string, Toast> = {
+  "report-success": {
+    title: "Infection reported!",
+    description: "Thank you! Stay safe out there!",
+    type: "success",
+    open: false,
+  },
+  "report-unauthorized": {
+    title: "Unauthorized",
+    description: "Your id doesn't match any we have in the system",
+    type: "error",
+    open: false,
+  },
+  "report-error": {
+    title: "Failed to report",
+    description: "An error occurred while adding your report to the system",
+    type: "error",
+    open: false,
+  },
+};
+
+interface UseReportInfectionProps {
+  identifier: string | null;
+  survivor: string;
+  onSuccess: () => void;
+}
+export const useReportInfection = ({
+  identifier,
+  survivor,
+  onSuccess,
+}: UseReportInfectionProps) => {
+  const { openToast, bulkRegisterToasts } = useToastsStore(
+    useShallow((state) => ({
+      openToast: state.actions.openToast,
+      bulkRegisterToasts: state.actions.bulkRegisterToasts,
+    })),
+  );
+  // Avoid updating ToastsEngine while this renders
+  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+
+  const mutationFn = useCallback(async () => {
+    const headers = new Headers();
+    headers.append("X-User-Id", identifier!);
+
+    const response = await fetch(`/api/survivors/${survivor}/report/`, {
+      method: "POST",
+      headers,
+    });
+
+    if (!response.ok) {
+      if (response.status === 401) {
+        openToast("report-unauthorized");
+        throw new Error("Unauthorized");
+      }
+      openToast("report-error");
+      throw new Error("An error occurred");
+    }
+    return await response.json();
+  }, [identifier, survivor, openToast]);
+
+  return useMutation({
+    mutationFn,
+    onSuccess,
+  });
+};

--- a/frontend/src/hooks/use-survivor.hook.ts
+++ b/frontend/src/hooks/use-survivor.hook.ts
@@ -3,43 +3,31 @@ import { useQuery } from "@tanstack/react-query";
 
 // internals
 import { QueryKeys } from "../constants";
-import { useToastsStore } from "../stores";
 import { ErrorState, Survivor } from "../types";
 
 interface UseSurvivorProps {
   enabled?: boolean;
   identifier: string | null;
   onSuccess?: (data: Survivor | ErrorState) => void;
+  onError: (err: Error) => void;
 }
 export const useSurvivor = ({
   enabled,
   identifier,
   onSuccess,
-}: UseSurvivorProps) => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
-
-  const { data, isFetching, refetch } = useQuery<Survivor | ErrorState>({
+  onError,
+}: UseSurvivorProps) =>
+  useQuery<Survivor | ErrorState>({
     queryKey: [QueryKeys.GetSurvivor, identifier],
     queryFn: async () => {
       const response = await fetch(`/api/survivors/${identifier}`);
 
       if (!response.ok) {
         if (response.status === 404) {
-          openToast({
-            id: "loadprofile-not-fount",
-            title: "Error",
-            description: "Could not find survivor in the system",
-            type: "error",
-          });
-          throw new Error("Not found");
+          onError(new Error("Not found"));
+          return;
         }
-        openToast({
-          id: "loadprofile-error",
-          title: "Error",
-          description: "An error occurred while loading survivor",
-          type: "error",
-        });
-        throw new Error("An error occurred");
+        onError(new Error("An error occurred"));
       }
 
       try {
@@ -47,17 +35,8 @@ export const useSurvivor = ({
         onSuccess?.(data);
         return data;
       } catch (err) {
-        openToast({
-          id: "loadprofile-data-corrupted",
-          title: "Error",
-          description: "Survivor data is corrupted",
-          type: "error",
-        });
-        throw err;
+        onError(err as Error);
       }
     },
     enabled,
   });
-
-  return { data, isFetching, refetch };
-};

--- a/frontend/src/hooks/use-survivor.hook.ts
+++ b/frontend/src/hooks/use-survivor.hook.ts
@@ -1,0 +1,77 @@
+// libs
+import { useQuery } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+
+// internals
+import { ErrorState, Survivor } from "../types";
+import { QueryKeys } from "../constants";
+import { Toast, useToastsStore } from "../stores";
+
+const TOASTS: Record<string, Toast> = {
+  "load-survivor-not-fount": {
+    title: "Error",
+    description: "Could not find survivor in the system",
+    type: "error",
+    open: false,
+  },
+  "load-survivor-error": {
+    title: "Error",
+    description: "An error occurred while loading survivor",
+    type: "error",
+    open: false,
+  },
+  "load-survivor-data-corrupted": {
+    title: "Error",
+    description: "Survivor data is corrupted",
+    type: "error",
+    open: false,
+  },
+};
+
+interface UseSurvivorProps {
+  enabled?: boolean;
+  identifier: string | null;
+  onSuccess?: (data: Survivor | ErrorState) => void;
+}
+export const useSurvivor = ({
+  enabled,
+  identifier,
+  onSuccess,
+}: UseSurvivorProps) => {
+  const { openToast, bulkRegisterToasts } = useToastsStore(
+    useShallow((state) => ({
+      openToast: state.actions.openToast,
+      bulkRegisterToasts: state.actions.bulkRegisterToasts,
+    })),
+  );
+  // Avoid updating ToastsEngine while this renders
+  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+
+  const { data, isFetching, refetch } = useQuery<Survivor | ErrorState>({
+    queryKey: [QueryKeys.GetSurvivor, identifier],
+    queryFn: async () => {
+      const response = await fetch(`/api/survivors/${identifier}`);
+
+      if (!response.ok) {
+        if (response.status === 404) {
+          openToast("loadprofile-not-fount");
+          throw new Error("Not found");
+        }
+        openToast("loadprofile-error");
+        throw new Error("An error occurred");
+      }
+
+      try {
+        const data = await response.json();
+        onSuccess?.(data);
+        return data;
+      } catch (err) {
+        openToast("loadprofile-data-corrupted");
+        throw err;
+      }
+    },
+    enabled,
+  });
+
+  return { data, isFetching, refetch };
+};

--- a/frontend/src/hooks/use-survivor.hook.ts
+++ b/frontend/src/hooks/use-survivor.hook.ts
@@ -1,32 +1,10 @@
 // libs
 import { useQuery } from "@tanstack/react-query";
-import { useShallow } from "zustand/react/shallow";
 
 // internals
-import { ErrorState, Survivor } from "../types";
 import { QueryKeys } from "../constants";
-import { Toast, useToastsStore } from "../stores";
-
-const TOASTS: Record<string, Toast> = {
-  "load-survivor-not-fount": {
-    title: "Error",
-    description: "Could not find survivor in the system",
-    type: "error",
-    open: false,
-  },
-  "load-survivor-error": {
-    title: "Error",
-    description: "An error occurred while loading survivor",
-    type: "error",
-    open: false,
-  },
-  "load-survivor-data-corrupted": {
-    title: "Error",
-    description: "Survivor data is corrupted",
-    type: "error",
-    open: false,
-  },
-};
+import { useToastsStore } from "../stores";
+import { ErrorState, Survivor } from "../types";
 
 interface UseSurvivorProps {
   enabled?: boolean;
@@ -38,14 +16,7 @@ export const useSurvivor = ({
   identifier,
   onSuccess,
 }: UseSurvivorProps) => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const { data, isFetching, refetch } = useQuery<Survivor | ErrorState>({
     queryKey: [QueryKeys.GetSurvivor, identifier],
@@ -54,10 +25,20 @@ export const useSurvivor = ({
 
       if (!response.ok) {
         if (response.status === 404) {
-          openToast("loadprofile-not-fount");
+          openToast({
+            id: "loadprofile-not-fount",
+            title: "Error",
+            description: "Could not find survivor in the system",
+            type: "error",
+          });
           throw new Error("Not found");
         }
-        openToast("loadprofile-error");
+        openToast({
+          id: "loadprofile-error",
+          title: "Error",
+          description: "An error occurred while loading survivor",
+          type: "error",
+        });
         throw new Error("An error occurred");
       }
 
@@ -66,7 +47,12 @@ export const useSurvivor = ({
         onSuccess?.(data);
         return data;
       } catch (err) {
-        openToast("loadprofile-data-corrupted");
+        openToast({
+          id: "loadprofile-data-corrupted",
+          title: "Error",
+          description: "Survivor data is corrupted",
+          type: "error",
+        });
         throw err;
       }
     },

--- a/frontend/src/hooks/use-survivors.hook.ts
+++ b/frontend/src/hooks/use-survivors.hook.ts
@@ -3,20 +3,19 @@ import { useQuery } from "@tanstack/react-query";
 
 // internals
 import { QueryKeys } from "../constants";
-import { useToastsStore } from "../stores";
 import { Survivor } from "../types";
 
 interface UseSurvivorsProps {
   identifier: string | null;
   maxDistance: number | null;
+  onError: (err: Error) => void;
 }
 export const useSurvivors = ({
   identifier,
   maxDistance,
-}: UseSurvivorsProps) => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
-
-  const { data, isFetching } = useQuery<Survivor[]>({
+  onError,
+}: UseSurvivorsProps) =>
+  useQuery<Survivor[]>({
     queryKey: [QueryKeys.GetSurvivors, identifier, maxDistance],
     queryFn: async () => {
       const headers = new Headers();
@@ -35,27 +34,12 @@ export const useSurvivors = ({
       });
 
       if (!response.ok) {
-        openToast({
-          id: "load-survivors-error",
-          title: "Error",
-          description: "An error occurred while loading survivors",
-          type: "error",
-        });
-        throw new Error("An error occurred");
+        onError(new Error("An error occurred"));
       }
       try {
         return response.json();
       } catch (err) {
-        openToast({
-          id: "load-survivors-data-corrupted",
-          title: "Error",
-          description: "Survivors data is corrupted",
-          type: "error",
-        });
-        throw err;
+        onError(err as Error);
       }
     },
   });
-
-  return { data, isFetching };
-};

--- a/frontend/src/hooks/use-survivors.hook.ts
+++ b/frontend/src/hooks/use-survivors.hook.ts
@@ -1,26 +1,10 @@
 // libs
 import { useQuery } from "@tanstack/react-query";
-import { useShallow } from "zustand/react/shallow";
 
 // internals
 import { QueryKeys } from "../constants";
-import { Toast, useToastsStore } from "../stores";
+import { useToastsStore } from "../stores";
 import { Survivor } from "../types";
-
-const TOASTS: Record<string, Toast> = {
-  "load-survivors-error": {
-    title: "Error",
-    description: "An error occurred while loading survivors",
-    type: "error",
-    open: false,
-  },
-  "load-survivors-data-corrupted": {
-    title: "Error",
-    description: "Survivors data is corrupted",
-    type: "error",
-    open: false,
-  },
-};
 
 interface UseSurvivorsProps {
   identifier: string | null;
@@ -30,15 +14,7 @@ export const useSurvivors = ({
   identifier,
   maxDistance,
 }: UseSurvivorsProps) => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const { data, isFetching } = useQuery<Survivor[]>({
     queryKey: [QueryKeys.GetSurvivors, identifier, maxDistance],
@@ -59,13 +35,23 @@ export const useSurvivors = ({
       });
 
       if (!response.ok) {
-        openToast("load-survivors-error");
+        openToast({
+          id: "load-survivors-error",
+          title: "Error",
+          description: "An error occurred while loading survivors",
+          type: "error",
+        });
         throw new Error("An error occurred");
       }
       try {
         return response.json();
       } catch (err) {
-        openToast("load-survivors-data-corrupted");
+        openToast({
+          id: "load-survivors-data-corrupted",
+          title: "Error",
+          description: "Survivors data is corrupted",
+          type: "error",
+        });
         throw err;
       }
     },

--- a/frontend/src/hooks/use-survivors.hook.ts
+++ b/frontend/src/hooks/use-survivors.hook.ts
@@ -1,0 +1,75 @@
+// libs
+import { useQuery } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+
+// internals
+import { QueryKeys } from "../constants";
+import { Toast, useToastsStore } from "../stores";
+import { Survivor } from "../types";
+
+const TOASTS: Record<string, Toast> = {
+  "load-survivors-error": {
+    title: "Error",
+    description: "An error occurred while loading survivors",
+    type: "error",
+    open: false,
+  },
+  "load-survivors-data-corrupted": {
+    title: "Error",
+    description: "Survivors data is corrupted",
+    type: "error",
+    open: false,
+  },
+};
+
+interface UseSurvivorsProps {
+  identifier: string | null;
+  maxDistance: number | null;
+}
+export const useSurvivors = ({
+  identifier,
+  maxDistance,
+}: UseSurvivorsProps) => {
+  const { openToast, bulkRegisterToasts } = useToastsStore(
+    useShallow((state) => ({
+      openToast: state.actions.openToast,
+      bulkRegisterToasts: state.actions.bulkRegisterToasts,
+    })),
+  );
+
+  // Avoid updating ToastsEngine while this renders
+  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+
+  const { data, isFetching } = useQuery<Survivor[]>({
+    queryKey: [QueryKeys.GetSurvivors, identifier, maxDistance],
+    queryFn: async () => {
+      const headers = new Headers();
+      if (identifier) {
+        headers.append("X-User-Id", identifier);
+      }
+
+      const search = new URLSearchParams();
+      if (maxDistance) {
+        search.append("max_distance", `${maxDistance}`);
+      }
+
+      const response = await fetch(`/api/survivors/?${search.toString()}`, {
+        method: "GET",
+        headers,
+      });
+
+      if (!response.ok) {
+        openToast("load-survivors-error");
+        throw new Error("An error occurred");
+      }
+      try {
+        return response.json();
+      } catch (err) {
+        openToast("load-survivors-data-corrupted");
+        throw err;
+      }
+    },
+  });
+
+  return { data, isFetching };
+};

--- a/frontend/src/hooks/use-trade.hook.ts
+++ b/frontend/src/hooks/use-trade.hook.ts
@@ -1,40 +1,17 @@
 // libs
 import { useMutation } from "@tanstack/react-query";
-import { useShallow } from "zustand/react/shallow";
 import { useCallback } from "react";
 
 // internals
-import { Toast, useToastsStore } from "../stores";
+import { useToastsStore } from "../stores";
 import { Survivor, Inventory as TInventory } from "../types";
-
-const TOASTS: Record<string, Toast> = {
-  "trade-error": {
-    title: "Trade failed",
-    description: "An error occurred while trading items",
-    type: "error",
-    open: false,
-  },
-  "trade-success": {
-    title: "Trade successful",
-    description: "Items have been traded successfully",
-    type: "success",
-    open: false,
-  },
-};
 
 interface UseTradeProps {
   identifier: string | null;
   onSuccess: (data: Survivor) => void;
 }
 export const useTrade = ({ identifier, onSuccess }: UseTradeProps) => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const mutationFn = useCallback(
     async (data: {
@@ -52,13 +29,23 @@ export const useTrade = ({ identifier, onSuccess }: UseTradeProps) => {
       });
 
       if (!response.ok) {
-        openToast("trade-error");
+        openToast({
+          id: "trade-error",
+          title: "Trade failed",
+          description: "An error occurred while trading items",
+          type: "error",
+        });
         throw new Error("Failed to trade");
       }
       try {
         return await response.json();
       } catch (err) {
-        openToast("trade-error");
+        openToast({
+          id: "trade-error",
+          title: "Trade failed",
+          description: "An error occurred while trading items",
+          type: "error",
+        });
         throw err;
       }
     },

--- a/frontend/src/hooks/use-trade.hook.ts
+++ b/frontend/src/hooks/use-trade.hook.ts
@@ -1,0 +1,72 @@
+// libs
+import { useMutation } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+import { useCallback } from "react";
+
+// internals
+import { Toast, useToastsStore } from "../stores";
+import { Survivor, Inventory as TInventory } from "../types";
+
+const TOASTS: Record<string, Toast> = {
+  "trade-error": {
+    title: "Trade failed",
+    description: "An error occurred while trading items",
+    type: "error",
+    open: false,
+  },
+  "trade-success": {
+    title: "Trade successful",
+    description: "Items have been traded successfully",
+    type: "success",
+    open: false,
+  },
+};
+
+interface UseTradeProps {
+  identifier: string | null;
+  onSuccess: (data: Survivor) => void;
+}
+export const useTrade = ({ identifier, onSuccess }: UseTradeProps) => {
+  const { openToast, bulkRegisterToasts } = useToastsStore(
+    useShallow((state) => ({
+      openToast: state.actions.openToast,
+      bulkRegisterToasts: state.actions.bulkRegisterToasts,
+    })),
+  );
+  // Avoid updating ToastsEngine while this renders
+  setTimeout(() => bulkRegisterToasts({ ...TOASTS }), 0);
+
+  const mutationFn = useCallback(
+    async (data: {
+      survivor_a_items: { survivor_id: string; items: TInventory };
+      survivor_b_items: { survivor_id: string; items: TInventory };
+    }) => {
+      const headers = new Headers();
+      headers.append("Content-Type", "application/json");
+      headers.append("X-User-Id", identifier!);
+
+      const response = await fetch("/api/survivors/trade/", {
+        method: "POST",
+        headers,
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        openToast("trade-error");
+        throw new Error("Failed to trade");
+      }
+      try {
+        return await response.json();
+      } catch (err) {
+        openToast("trade-error");
+        throw err;
+      }
+    },
+    [identifier, openToast],
+  );
+
+  return useMutation({
+    mutationFn,
+    onSuccess,
+  });
+};

--- a/frontend/src/hooks/use-trade.hook.ts
+++ b/frontend/src/hooks/use-trade.hook.ts
@@ -3,16 +3,14 @@ import { useMutation } from "@tanstack/react-query";
 import { useCallback } from "react";
 
 // internals
-import { useToastsStore } from "../stores";
 import { Survivor, Inventory as TInventory } from "../types";
 
 interface UseTradeProps {
   identifier: string | null;
   onSuccess: (data: Survivor) => void;
+  onError: (err: Error) => void;
 }
-export const useTrade = ({ identifier, onSuccess }: UseTradeProps) => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
-
+export const useTrade = ({ identifier, onSuccess, onError }: UseTradeProps) => {
   const mutationFn = useCallback(
     async (data: {
       survivor_a_items: { survivor_id: string; items: TInventory };
@@ -29,31 +27,16 @@ export const useTrade = ({ identifier, onSuccess }: UseTradeProps) => {
       });
 
       if (!response.ok) {
-        openToast({
-          id: "trade-error",
-          title: "Trade failed",
-          description: "An error occurred while trading items",
-          type: "error",
-        });
         throw new Error("Failed to trade");
       }
-      try {
-        return await response.json();
-      } catch (err) {
-        openToast({
-          id: "trade-error",
-          title: "Trade failed",
-          description: "An error occurred while trading items",
-          type: "error",
-        });
-        throw err;
-      }
+      return await response.json();
     },
-    [identifier, openToast],
+    [identifier],
   );
 
   return useMutation({
     mutationFn,
     onSuccess,
+    onError,
   });
 };

--- a/frontend/src/hooks/use-update-survivor.hook.ts
+++ b/frontend/src/hooks/use-update-survivor.hook.ts
@@ -5,7 +5,7 @@ import { useShallow } from "zustand/react/shallow";
 
 // internals
 import { Toast, useToastsStore } from "../stores";
-import { LatLon, Survivor } from "../types";
+import { LatLonBase, Survivor } from "../types";
 
 const TOASTS: Record<string, Toast> = {
   "location-update-success": {
@@ -46,7 +46,7 @@ export const useUpdateSurvivor = ({
   setTimeout(() => bulkRegisterToasts({ ...TOASTS }));
 
   const mutationFn = useCallback(
-    async (data: LatLon) => {
+    async (data: LatLonBase) => {
       const headers = new Headers();
       headers.append("Content-Type", "application/json");
       headers.append("X-User-Id", identifier!);

--- a/frontend/src/hooks/use-update-survivor.hook.ts
+++ b/frontend/src/hooks/use-update-survivor.hook.ts
@@ -1,32 +1,9 @@
 // libs
 import { useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { useShallow } from "zustand/react/shallow";
-
 // internals
-import { Toast, useToastsStore } from "../stores";
+import { useToastsStore } from "../stores";
 import { LatLonBase, Survivor } from "../types";
-
-const TOASTS: Record<string, Toast> = {
-  "location-update-success": {
-    title: "Location updated",
-    description: "Your location has been updated successfully",
-    type: "success",
-    open: false,
-  },
-  "location-update-error": {
-    title: "Location update failed",
-    description: "An error occurred while updating your location",
-    type: "error",
-    open: false,
-  },
-  "location-update-unauthorized": {
-    title: "Location update failed",
-    description: "You are not authorized to update another survivor's location",
-    type: "error",
-    open: false,
-  },
-};
 
 interface UseUpdateSurvivorProps {
   identifier: string | null;
@@ -36,14 +13,7 @@ export const useUpdateSurvivor = ({
   identifier,
   onSuccess,
 }: UseUpdateSurvivorProps) => {
-  const { openToast, bulkRegisterToasts } = useToastsStore(
-    useShallow((state) => ({
-      openToast: state.actions.openToast,
-      bulkRegisterToasts: state.actions.bulkRegisterToasts,
-    })),
-  );
-  // Avoid updating ToastsEngine while this renders
-  setTimeout(() => bulkRegisterToasts({ ...TOASTS }));
+  const openToast = useToastsStore((state) => state.actions.openToast);
 
   const mutationFn = useCallback(
     async (data: LatLonBase) => {
@@ -60,17 +30,33 @@ export const useUpdateSurvivor = ({
       if (!response.ok) {
         const errorData = await response.json().catch(() => null);
         if (errorData?.status === 401) {
-          openToast("location-update-unauthorized");
+          openToast({
+            id: "location-update-unauthorized",
+            title: "Location update failed",
+            description:
+              "You are not authorized to update another survivor's location",
+            type: "error",
+          });
           throw new Error("Unauthorized");
         }
-        openToast("location-update-error");
+        openToast({
+          id: "location-update-error",
+          title: "Location update failed",
+          description: "An error occurred while updating your location",
+          type: "error",
+        });
         throw new Error(errorData?.detail ?? "An error occurred");
       }
 
       try {
         return await response.json();
       } catch (err) {
-        openToast("location-update-error");
+        openToast({
+          id: "location-update-error",
+          title: "Location update failed",
+          description: "An error occurred while updating your location",
+          type: "error",
+        });
         throw err;
       }
     },

--- a/frontend/src/hooks/use-update-survivor.hook.ts
+++ b/frontend/src/hooks/use-update-survivor.hook.ts
@@ -1,0 +1,84 @@
+// libs
+import { useCallback } from "react";
+import { useMutation } from "@tanstack/react-query";
+import { useShallow } from "zustand/react/shallow";
+
+// internals
+import { Toast, useToastsStore } from "../stores";
+import { LatLon, Survivor } from "../types";
+
+const TOASTS: Record<string, Toast> = {
+  "location-update-success": {
+    title: "Location updated",
+    description: "Your location has been updated successfully",
+    type: "success",
+    open: false,
+  },
+  "location-update-error": {
+    title: "Location update failed",
+    description: "An error occurred while updating your location",
+    type: "error",
+    open: false,
+  },
+  "location-update-unauthorized": {
+    title: "Location update failed",
+    description: "You are not authorized to update another survivor's location",
+    type: "error",
+    open: false,
+  },
+};
+
+interface UseUpdateSurvivorProps {
+  identifier: string | null;
+  onSuccess: (data: Survivor) => void;
+}
+export const useUpdateSurvivor = ({
+  identifier,
+  onSuccess,
+}: UseUpdateSurvivorProps) => {
+  const { openToast, bulkRegisterToasts } = useToastsStore(
+    useShallow((state) => ({
+      openToast: state.actions.openToast,
+      bulkRegisterToasts: state.actions.bulkRegisterToasts,
+    })),
+  );
+  // Avoid updating ToastsEngine while this renders
+  setTimeout(() => bulkRegisterToasts({ ...TOASTS }));
+
+  const mutationFn = useCallback(
+    async (data: LatLon) => {
+      const headers = new Headers();
+      headers.append("Content-Type", "application/json");
+      headers.append("X-User-Id", identifier!);
+
+      const response = await fetch(`/api/survivors/${identifier}/location/`, {
+        method: "PUT",
+        headers,
+        body: JSON.stringify(data),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json().catch(() => null);
+        if (errorData?.status === 401) {
+          openToast("location-update-unauthorized");
+          throw new Error("Unauthorized");
+        }
+        openToast("location-update-error");
+        throw new Error(errorData?.detail ?? "An error occurred");
+      }
+
+      try {
+        return await response.json();
+      } catch (err) {
+        openToast("location-update-error");
+        throw err;
+      }
+    },
+    [identifier, openToast],
+  );
+
+  return useMutation({
+    mutationFn,
+    onSuccess,
+  });
+};

--- a/frontend/src/hooks/use-update-survivor.hook.ts
+++ b/frontend/src/hooks/use-update-survivor.hook.ts
@@ -2,19 +2,18 @@
 import { useCallback } from "react";
 import { useMutation } from "@tanstack/react-query";
 // internals
-import { useToastsStore } from "../stores";
 import { LatLonBase, Survivor } from "../types";
 
 interface UseUpdateSurvivorProps {
   identifier: string | null;
   onSuccess: (data: Survivor) => void;
+  onError: (err: Error) => void;
 }
 export const useUpdateSurvivor = ({
   identifier,
   onSuccess,
+  onError,
 }: UseUpdateSurvivorProps) => {
-  const openToast = useToastsStore((state) => state.actions.openToast);
-
   const mutationFn = useCallback(
     async (data: LatLonBase) => {
       const headers = new Headers();
@@ -30,41 +29,18 @@ export const useUpdateSurvivor = ({
       if (!response.ok) {
         const errorData = await response.json().catch(() => null);
         if (errorData?.status === 401) {
-          openToast({
-            id: "location-update-unauthorized",
-            title: "Location update failed",
-            description:
-              "You are not authorized to update another survivor's location",
-            type: "error",
-          });
           throw new Error("Unauthorized");
         }
-        openToast({
-          id: "location-update-error",
-          title: "Location update failed",
-          description: "An error occurred while updating your location",
-          type: "error",
-        });
         throw new Error(errorData?.detail ?? "An error occurred");
       }
-
-      try {
-        return await response.json();
-      } catch (err) {
-        openToast({
-          id: "location-update-error",
-          title: "Location update failed",
-          description: "An error occurred while updating your location",
-          type: "error",
-        });
-        throw err;
-      }
+      return await response.json();
     },
-    [identifier, openToast],
+    [identifier],
   );
 
   return useMutation({
     mutationFn,
     onSuccess,
+    onError,
   });
 };

--- a/frontend/src/stores/toasts.store.ts
+++ b/frontend/src/stores/toasts.store.ts
@@ -4,56 +4,25 @@ import { create } from "zustand";
 // internals
 import { ToastType } from "../components";
 
-export type Toast = {
+export type ToastBase = {
+  id: string;
   title?: string;
   description?: string;
   type: ToastType;
+};
+export type Toast = ToastBase & {
   open: boolean;
 };
 interface ToastStoreState {
   toasts: Record<string, Toast>;
   actions: {
-    registerToast: (id: string, toast: Toast) => void;
-    bulkRegisterToasts: (toasts: Record<string, Toast>) => void;
-    openToast: (id: string) => void;
     toggleToast: (id: string) => (open: boolean) => void;
+    openToast: (toast: ToastBase) => void;
   };
 }
 export const useToastsStore = create<ToastStoreState>((set) => ({
   toasts: {},
   actions: {
-    registerToast: (id, toast) => {
-      set((state) =>
-        id in state.toasts ?
-          state
-        : { ...state, toasts: { ...state.toasts, [id]: toast } },
-      );
-    },
-    bulkRegisterToasts: (toasts) => {
-      set((state) => {
-        const toastsToAdd: Record<string, Toast> = {};
-        for (const key in toasts) {
-          if (!(key in state.toasts)) {
-            toastsToAdd[key] = toasts[key];
-          }
-        }
-        if (Object.keys(toastsToAdd).length === 0) {
-          return state;
-        }
-        return { ...state, toasts: { ...state.toasts, ...toastsToAdd } };
-      });
-    },
-    openToast: (id) => {
-      set((state) => {
-        return {
-          ...state,
-          toasts: {
-            ...state.toasts,
-            [id]: { ...state.toasts[id], open: true },
-          },
-        };
-      });
-    },
     toggleToast: (id) => (open) => {
       set((state) => ({
         ...state,
@@ -62,6 +31,17 @@ export const useToastsStore = create<ToastStoreState>((set) => ({
           [id]: { ...state.toasts[id], open },
         },
       }));
+    },
+    openToast: (toast) => {
+      set((state) => {
+        return {
+          ...state,
+          toasts: {
+            ...state.toasts,
+            [toast.id]: { ...(state.toasts[toast.id] ?? toast), open: true },
+          },
+        };
+      });
     },
   },
 }));

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,8 +16,8 @@ export type Item = {
 export type InfectionReport = {
   id?: string;
   created_at: Date;
-  reporter_id: string;
-  reported_id: string;
+  reporter_id: Survivor["id"];
+  reported_id: Survivor["id"];
 };
 
 export type Inventory = Record<Item["id"], number>;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -1,35 +1,42 @@
-export type Gender = "m" | "f";
-
-export type LatLon = {
-  id?: string;
-  latitude: number;
-  longitude: number;
-  distance?: number;
-};
-
 export type Item = {
   id: string;
   label: string;
   worth: number;
 };
 
-export type InfectionReport = {
-  id?: string;
+export type Gender = "m" | "f";
+
+export type LatLonBase = {
+  latitude: number;
+  longitude: number;
+};
+export type LatLon = LatLonBase & {
+  id: string;
+  distance: number;
+};
+
+export type InfectionReportBase = {
   created_at: Date;
   reporter_id: Survivor["id"];
   reported_id: Survivor["id"];
 };
+export type InfectionReport = InfectionReportBase & {
+  id: string;
+};
 
 export type Inventory = Record<Item["id"], number>;
 
-export type Survivor = {
-  id?: string;
+export type SurvivorBase = {
   name: string;
   age: number;
   gender: Gender;
-  lastLocation: LatLon;
   inventory: Inventory;
-  infectionReports?: InfectionReport[];
+  lastLocation: LatLonBase;
+};
+export type Survivor = SurvivorBase & {
+  id: string;
+  infectionReports: InfectionReport[];
+  lastLocation: LatLon;
 };
 
 export type ErrorState = { detail: string };


### PR DESCRIPTION
With this PR, I am making some architectural adjustments based on feedback received in interview.
- [x] Handle query keys in a better way to avoid spelling mistakes (central enum created)
- [x] Reduce size and complexity of API functionality (moved all queries and mutations into separate hooks)
- [x] De-couple API logic from components and surrounding environment (API logic is now driven by params)
- [x] Revise Toast solution to leverage built-in functionality - Can't find any on Radix-UI... (Improved store logic by abolishing toast registration and declarative logic)
- [x] Trading panel logic
- [x] Easily handle updates to survivor infections threshold (centralised the threshold as a constant and added a simple checker function)
- [x] Stronger typing in the fe (Added specific types for create payloads and extended the full version from them)